### PR TITLE
fix a never-resolved defer in coap-shepherd.announce()

### DIFF
--- a/lib/coap-shepherd.js
+++ b/lib/coap-shepherd.js
@@ -276,7 +276,7 @@ CoapShepherd.prototype.announce = function (msg, callback) {
     var deferred = Q.defer(),
         shepherd = this,
         announceAllClient = [],
-        count = this._registry.lenght,
+        count = Object.keys(this._registry).length,
         reqObj = {
             hostname: null,
             port: null,


### PR DESCRIPTION
Hi,

I found a bug in lib/coap-shepherd.js line 279:

1, "lenght" is a typo;
2, "this._registry" is an object, not an array, thus, do not have a length property.

So "count" will be "undefined" first, and then "NaN" after "count -= 1", which means "count === 0" will never be true, and "deferred.resolve(msg);" will never be called.

This pull request should do the work, please accept it.

Best Regards,
Mophy Xiong