### PR TITLE
add `config` argument to CoapShepherd constructor

### DIFF
--- a/lib/coap-shepherd.js
+++ b/lib/coap-shepherd.js
@@ -18,24 +18,29 @@ var CoapNode = require('./components/coap-node'),
     Coapdb = require('./components/coapdb'),
     cutils = require('./components/cutils'),
     CNST = require('./components/constants'),
-    config = require('./config'),
+    defaultConfig = require('./config'),
     init = require('./init');
-
-var reqTimeout = config.reqTimeout || 60,
-    hbTimeout = config.hbTimeout || 60;
 
 /**** Code Enumerations ****/
 var RSP = CNST.RSP;
 
-function CoapShepherd() {
+function CoapShepherd(config) {
+    if (undefined !== config)
+        proving.object(config, 'config should be an object if given.');
+
     EventEmitter.call(this);
 
     this.clientIdCount = 1;
+    this._config = config ? Object.assign(defaultConfig, config) : defaultConfig;
+    this._config.ip = this._config.ip || '';
+    this._config.port = this._config.port || 5683;
+    this._config.reqTimeout = this._config.reqTimeout || 60;
+    this._config.hbTimeout = this._config.hbTimeout || 60;
 
     this._net = {
         intf: '',
-        ip: config.ip || '',
-        port: config.port || 5683,
+        ip: this._config.ip,
+        port: this._config.port,
         mac: '',
         routerIp: ''
     };
@@ -50,18 +55,16 @@ function CoapShepherd() {
     this._permitJoinTime = 0; 
     this._permitJoinTimer = null;
 
-    this._dbPath = config.defaultDbPath;
-
     try {
-        fs.statSync(config.defaultDbFolder);
+        fs.statSync(this._config.defaultDbFolder);
     } catch (e) {
-        fs.mkdirSync(config.defaultDbFolder);
+        fs.mkdirSync(this._config.defaultDbFolder);
     }
 
-    this._coapdb = new Coapdb(this._dbPath);
+    this._coapdb = new Coapdb(this._config.defaultDbPath);
 
     coap.updateTiming({
-        maxLatency: (reqTimeout - 47) / 2
+        maxLatency: (this._config.reqTimeout - 47) / 2
     });
 
     this._acceptDevIncoming = function (devInfo, callback) {   // Override at will.
@@ -142,7 +145,7 @@ CoapShepherd.prototype.reset = function (mode, callback) {
                 });
             });
         } else {
-            shepherd._coapdb = new Coapdb(shepherd._dbPath);
+            shepherd._coapdb = new Coapdb(shepherd._config.defaultDbPath);
         }
     }
 
@@ -435,7 +438,7 @@ function hbCheck (shepherd, enabled) {
             _.forEach(shepherd._registry, function (cn) {
                 var now = cutils.getTime();
                 
-                if (cn.status === 'online' && cn.heartbeatEnabled && ((now - cn._heartbeat) > hbTimeout)) {
+                if (cn.status === 'online' && cn.heartbeatEnabled && ((now - cn._heartbeat) > shepherd._config.hbTimeout)) {
                     cn._setStatus('offline');
 
                     cn.pingReq().done(function (rspObj) {
@@ -450,7 +453,7 @@ function hbCheck (shepherd, enabled) {
                     });
                 }
             });
-        }, hbTimeout * 1000);
+        }, shepherd._config.hbTimeout * 1000);
     }
 }
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -3,37 +3,13 @@
 var Q = require('q'),
     _ = require('busyman'),
     coap = require('coap'),
+    network = require('network'),
     debug = require('debug')('coap-shepherd:init');
 
 var reqHandler = require('./components/reqHandler'),
     CoapNode = require('./components/coap-node'),
     cutils = require('./components/cutils'),
-    CNST = require('./components/constants'),
-    config = require('./config');
-
-if (process.env.npm_lifecycle_event === 'test') {
-    var network = {
-        get_active_interface: function (cb) {
-            setTimeout(function () {
-                if (config.connectionType === 'udp6') {
-                    cb(null, {
-                        ip_address: '::1',
-                        gateway_ip: '::c0a8:0101',
-                        mac_address: '00:00:00:00:00:00'
-                    });
-                } else {
-                    cb(null, {
-                        ip_address: '127.0.0.1',
-                        gateway_ip: '192.168.1.1',
-                        mac_address: '00:00:00:00:00:00'
-                    });
-                }
-            }, 100);
-        }
-    };
-} else {
-    var network = require('network');
-}
+    CNST = require('./components/constants');
 
 /**** Code Enumerations ****/
 var RSP = CNST.RSP;
@@ -84,7 +60,7 @@ init.setupShepherd = function (shepherd, callback) {
 init._coapServerStart = function (shepherd, callback) {
     var deferred = Q.defer(),
         server = coap.createServer({
-            type: config.connectionType
+            type: shepherd._config.connectionType
         });
 
     server.on('request', function (req, rsp) {
@@ -101,16 +77,16 @@ init._coapServerStart = function (shepherd, callback) {
             deferred.resolve(server);
     });
 
-    if (config.connectionType === 'udp6') {
+    if (shepherd._config.connectionType === 'udp6') {
         coap.globalAgentIPv6 = new coap.Agent({
-            type: config.connectionType,
+            type: shepherd._config.connectionType,
             socket: server._sock
         });
 
         shepherd._agent = coap.globalAgentIPv6;
     } else {
         coap.globalAgent = new coap.Agent({
-            type: config.connectionType,
+            type: shepherd._config.connectionType,
             socket: server._sock
         });
         


### PR DESCRIPTION
Add `config` argument to CoapShepherd constructor, without changing entrance signature.