### PR TITLE
fix observe stream not using the latest `Content-Format`

### DIFF
--- a/lib/components/coap-node.js
+++ b/lib/components/coap-node.js
@@ -259,7 +259,6 @@ CoapNode.prototype.observeReq = function (path, callback) {
             isRspTimeout(observeStream, self);
 
             if (observeStream.code === RSP.content) {
-                type = observeStream.headers['Content-Format'];
                 rspObj.data = observeStream.payload;
                 observeStream._disableFiltering = self.shepherd._config.disableFiltering;
 
@@ -270,6 +269,7 @@ CoapNode.prototype.observeReq = function (path, callback) {
 
                 observeStream.once('data', function (value) {
                     observeStream.on('data', function (value) {
+                        type = observeStream.headers['Content-Format'];
                         notifyHandler(self, path, value, type);
                     });
                 });


### PR DESCRIPTION
Some device will change their `Content-Format` during observing/notifying process. So we have to use the latest `Content-Format`, otherwise, newly-coming data will not be decoded properly.