### PR TITLE
Dynamic initialisation of cshepherd for high scalability

### DIFF
--- a/lib/coap-shepherd.js
+++ b/lib/coap-shepherd.js
@@ -455,5 +455,5 @@ function hbCheck (shepherd, enabled) {
 var coapShepherd = new CoapShepherd();
 module.exports = coapShepherd;
 
-module.exports.custom = ( arg1) => { return new CoapShepherd( arg1) }
+module.exports.custom = ( config) => { return new CoapShepherd( config) }
 

--- a/lib/coap-shepherd.js
+++ b/lib/coap-shepherd.js
@@ -453,5 +453,7 @@ function hbCheck (shepherd, enabled) {
 }
 
 var coapShepherd = new CoapShepherd();
-
 module.exports = coapShepherd;
+
+module.exports.custom = ( arg1) => { return new CoapShepherd( arg1) }
+


### PR DESCRIPTION
Allows a config object containing i.e. port number for socket establishment or alternatively a custom server socket (i,e. instance of eventEmitter) to be passed as port parameter on the fly during instantiation of cshepherd. 
```
Example:
let config = {port:5500}; //or let config = {port:custom_socket};
let cshepherd = require('coap-shepherd').custom(config);

//use of legacy defaultConfig still remains valid with:
let cshepherd = require('coap-shepherd');

```

This port config will be passed on to the underlying node-coap library. 
Note: to use custom socket one must ensure the CoAPServer.prototype.listen section in the local coap server.js library install is updated as per the latest version as defined in node-coap (v0.23.1).