### PR TITLE
fix a crash when `ep` not passed in when device registering; add `cli…

### DIFF
--- a/lib/components/reqHandler.js
+++ b/lib/components/reqHandler.js
@@ -51,17 +51,17 @@ function clientReqHandler(shepherd, req, rsp) {
 }
 
 function clientRegisterHandler (shepherd, req, rsp) {
-    var devAttrs = buildDevAttrs(req),
-        cnode = shepherd.find(devAttrs.clientName),
+    var devAttrs = buildDevAttrs(shepherd, req),
+        cnode = (devAttrs && devAttrs.clientName) ? shepherd.find(devAttrs.clientName) : null,
         errCount = 0;
 
     debug('REQ <-- register, token: %s', req._packet ? req._packet.token.toString('hex') : undefined);
 
-    if (devAttrs === false || !devAttrs.clientName || !devAttrs.objList) 
+    if (devAttrs === false || !devAttrs.clientName || !devAttrs.objList)
         return sendRsp(rsp, RSP.badreq, '', 'register');
-    else if (shepherd._joinable === false) 
+    else if (shepherd._joinable === false)
         return sendRsp(rsp, RSP.notallowed, '', 'register');
-    
+
     function getClientDetails(notFire) {
         setTimeout(function() {
             cnode = shepherd.find(devAttrs.clientName);
@@ -78,8 +78,8 @@ function clientRegisterHandler (shepherd, req, rsp) {
                         return cnode.observeReq('/heartbeat');
                 }).then(function () {
                     if (!notFire) {
-                        fireImmediate(shepherd, 'ind', { 
-                            type: 'devIncoming', 
+                        fireImmediate(shepherd, 'ind', {
+                            type: 'devIncoming',
                             cnode: cnode
                         });
                     }
@@ -97,7 +97,7 @@ function clientRegisterHandler (shepherd, req, rsp) {
                 }).done();
             } else {
                 // [TODO]
-            }            
+            }
         }, 100);
     }
 
@@ -141,7 +141,7 @@ function clientRegisterHandler (shepherd, req, rsp) {
             cnode.lifeCheck(true);
             rsp.setOption('Location-Path', [new Buffer('rd'), new Buffer(cnode.clientId.toString())]);
             sendRsp(rsp, RSP.created, '', 'register');
-            return getClientDetails(true);
+            return getClientDetails(!shepherd._config.alwaysFireDevIncoming);
         }, function (err) {
             sendRsp(rsp, RSP.serverError, '', 'register');
             shepherd.emit('error', err);
@@ -150,15 +150,15 @@ function clientRegisterHandler (shepherd, req, rsp) {
 }
 
 function clientUpdateHandler (shepherd, req, rsp) {
-    var devAttrs = buildDevAttrs(req),
+    var devAttrs = buildDevAttrs(shepherd, req),
         locationPath = cutils.urlParser(req.url).pathname,
         cnode = shepherd._findByLocationPath(locationPath),
         diff,
         msg = {};
-        
+
     debug('REQ <-- update, token: %s', req._packet ? req._packet.token.toString('hex') : undefined);
 
-    if (devAttrs === false) 
+    if (devAttrs === false)
         return sendRsp(rsp, RSP.badreq, '', 'update');
 
     if (cnode) {
@@ -179,10 +179,10 @@ function clientUpdateHandler (shepherd, req, rsp) {
                 msg[key] = val;
             });
 
-            fireImmediate(shepherd, 'ind', { 
-                type: 'devUpdate', 
+            fireImmediate(shepherd, 'ind', {
+                type: 'devUpdate',
                 cnode: cnode,
-                data: msg 
+                data: msg
             });
         }, function (err) {
             sendRsp(rsp, RSP.serverError, '', 'update');
@@ -198,7 +198,7 @@ function clientDeregisterHandler (shepherd, req, rsp) {
         cnode = shepherd._findByLocationPath(locationPath),
         clientName = cnode.clientName,
         mac = cnode.mac;
-        
+
     debug('REQ <-- deregister, token: %s', req._packet ? req._packet.token.toString('hex') : undefined);
 
     if (cnode) {
@@ -221,7 +221,7 @@ function clientCheckHandler (shepherd, req, rsp) {
 
     debug('REQ <-- check, token: %s', req._packet ? req._packet.token.toString('hex') : undefined);
 
-    if (chkAttrs === false) 
+    if (chkAttrs === false)
         return sendRsp(rsp, RSP.badreq, '', 'check');
 
     function startHeartbeat() {
@@ -267,10 +267,11 @@ function clientCheckHandler (shepherd, req, rsp) {
 
 function clientLookupHandler (shepherd, req, rsp) {
     var lookupType = cutils.getPathArray(req.url)[1],
-        clientName = buildDevAttrs(req).clientName,
-        cnode = shepherd.find(clientName),
+        devAttrs = buildDevAttrs(shepherd, req),
+        clientName = devAttrs ? devAttrs.clientName : '',
+        cnode = clientName ? shepherd.find(devAttrs.clientName) : null,
         data;
-        
+
     debug('REQ <-- lookup, token: %s', req._packet ? req._packet.token.toString('hex') : undefined);
 // [TODO] check pathname & lookupType
     if (cnode) {
@@ -278,7 +279,7 @@ function clientLookupHandler (shepherd, req, rsp) {
         sendRsp(rsp, RSP.content, data, 'lookup');
         fireImmediate(shepherd, 'ind', { type: 'lookup' , data: clientName });
     } else {
-        sendRsp(rsp, RSP.notfound, '', 'lookup');
+        sendRsp(rsp, clientName ? RSP.notfound : RSP.badreq, '', 'lookup');
     }
 }
 
@@ -301,7 +302,7 @@ function clientReqParser (req) {
     switch (req.method) {
         case 'POST':
             pathArray = cutils.getPathArray(req.url);
-            if (pathArray.length === 1 && pathArray[0] === 'rd') 
+            if (pathArray.length === 1 && pathArray[0] === 'rd')
                 optType = 'register';
             else
                 optType = 'update';
@@ -314,9 +315,9 @@ function clientReqParser (req) {
             break;
         case 'GET':
             pathArray = cutils.getPathArray(req.url);
-            if (pathArray[0] === 'test') 
+            if (pathArray[0] === 'test')
                 optType = 'test';
-            else 
+            else
                 optType = 'lookup';
             break;
         default:
@@ -332,10 +333,10 @@ function sendRsp(rsp, code, data, optType) {
     debug('RSP --> %s, token: %s', optType, rsp._packet ? rsp._packet.token.toString('hex') : undefined);
 }
 
-function buildDevAttrs(req) {
-    var devAttrs = {},  
+function buildDevAttrs(shepherd, req) {
+    var devAttrs = {},
         query = req.url ? req.url.split('?')[1] : undefined,    // 'ep=clientName&lt=86400&lwm2m=1.0.0'
-        queryParams = query ? query.split('&') : undefined, 
+        queryParams = query ? query.split('&') : undefined,
         invalidAttrs = [],
         obj;
 
@@ -343,7 +344,7 @@ function buildDevAttrs(req) {
         queryParams[idx] = queryParam.split('=');
     });
 
-    _.forEach(queryParams, function(queryParam) {     
+    _.forEach(queryParams, function(queryParam) {
         if(queryParam[0] === 'ep') {
             devAttrs.clientName = queryParam[1];
         } else if (queryParam[0] === 'lt') {
@@ -369,6 +370,10 @@ function buildDevAttrs(req) {
         devAttrs.heartbeatEnabled = obj.opts.hb;
     }
 
+    if (devAttrs.clientName && ('function' === typeof shepherd._config.clientNameParser)) {
+        devAttrs.clientName = shepherd._config.clientNameParser(devAttrs.clientName);
+    }
+
     if (invalidAttrs.length > 0) {
         devAttrs = false;
     }
@@ -377,16 +382,16 @@ function buildDevAttrs(req) {
 }
 
 function buildChkAttrs(req) {
-    var chkAttrs = {},  
+    var chkAttrs = {},
         query = req.url ? req.url.split('?')[1] : undefined,    // 'chk=out&t=300'
-        queryParams = query ? query.split('&') : undefined, 
+        queryParams = query ? query.split('&') : undefined,
         invalidAttrs = [];
 
     _.forEach(queryParams, function (queryParam, idx) {
         queryParams[idx] = queryParam.split('=');
     });
 
-    _.forEach(queryParams, function(queryParam) {     
+    _.forEach(queryParams, function(queryParam) {
         if(queryParam[0] === 'chk') {
             if (queryParam[1] === 'in')
                 chkAttrs.sleep = false;
@@ -409,7 +414,7 @@ function buildChkAttrs(req) {
 function fireImmediate(shepherd, evt, msg) { // (shepherd, evt, ...)
     setImmediate(function () {
         shepherd.emit(evt, msg);
-    }); 
+    });
 }
 
 /*********************************************************

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,14 +3,14 @@
 module.exports = {
     // indicates if the server should create IPv4 connections (udp4) or IPv6 connections (udp6).
     // default is udp4.
-    connectionType: 'udp4', 
+    connectionType: 'udp4',
 
     // the cserver's ip address.
     ip: '127.0.0.1',
 
     // the cserver's COAP server will start listening.
     // default is 5683.
-    port: 5683, 
+    port: 5683,
 
     // storage for cnode persistence, should be an instance of StorageInterface if specified.
     // default is an instance of NedbStorage with `this.defaultDbPath` as storage file.
@@ -31,6 +31,13 @@ module.exports = {
     // disable filtering for observed client packets. details:
     // https://github.com/mcollina/node-coap/issues/200
     disableFiltering: false,
+
+    // a function to parse clientName. some clients may send 'urn:123456' as clientName,
+    // you can use your own clientNameParser to keep just the '123456' part as clientName.
+    clientNameParser: function (clientName) { return clientName; },
+
+    // always fire devIncoming event, even if client is already online when registering.
+    alwaysFireDevIncoming: false,
 
     // path to the file where the data is persisted, if default NedbStorage is used.
     // default is ./lib/database/coap.db.

--- a/test/fixture.js
+++ b/test/fixture.js
@@ -84,7 +84,7 @@ function _verifySignatureAsync(func, acceptedTypes) {
 function _fireSetTimeoutCallbackEarlier(counter, delay) {
     counter = counter || 1;
     delay = delay || 50;
-    var timerCb;
+    var timerCb, callTimerCb;
 
     global.setTimeout = function (cb, delay) {
         if (!--counter) {
@@ -96,9 +96,13 @@ function _fireSetTimeoutCallbackEarlier(counter, delay) {
             return _globalSetTimeout(cb, delay);
     };
 
-    _globalSetTimeout(function () {
-        timerCb();
-    }, delay);
+    callTimerCb = function () {
+        if (timerCb)
+            timerCb();
+        else
+            _globalSetTimeout(callTimerCb, delay);
+    };
+    _globalSetTimeout(callTimerCb, delay);
 }
 
 module.exports = {


### PR DESCRIPTION
fix a crash when `ep` not passed in when device registering;
add `clientNameParser` config options (some clients may send `urn:123456` as `clientName`, through this option, you can use your own `clientNameParser` to keep just the `123456` part as `clientName`);
add `alwaysFireDevIncoming` config options (always fire `devIncoming` ind event, even if client is already online when registering, default value: `false`).